### PR TITLE
Use Bourne shell instead of Bash in packaging script

### DIFF
--- a/build/package.sh
+++ b/build/package.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -eu
 cd "$(dirname "$0")/../"
 


### PR DESCRIPTION
This is because our dcind image used in Concourse pipelines doesn't have Bash.