### PR TITLE
Improve Slack notification message format, and refactor for readability and PEP8

### DIFF
--- a/src/event_handler.py
+++ b/src/event_handler.py
@@ -7,15 +7,30 @@ from base64 import b64decode
 from urllib.request import Request, urlopen
 from urllib.error import URLError, HTTPError
 
-
-# The base-64 encoded, encrypted key (CiphertextBlob) stored in the ENCRYPTED_SLACK_WEBHOOK_URL environment variable
+# KMS-encrypted ciphertext. Note that the ciphertext has been base64-encoded, in order for the
+# ciphertext to be represented as string (KMS CLI does this automatically when specifying output
+# as text). It will, therefore, need to be decoded first before decrypting (like done below).
 ENCRYPTED_HOOK_URL = os.environ['ENCRYPTED_SLACK_WEBHOOK_URL']
 SLACK_CHANNEL = os.environ['SLACK_CHANNEL']
 
-HOOK_URL = "https://" + boto3.client('kms').decrypt(CiphertextBlob=b64decode(ENCRYPTED_HOOK_URL))['Plaintext'].decode('utf-8')
+decrypted_hook_url = boto3.client('kms').decrypt(CiphertextBlob=b64decode(ENCRYPTED_HOOK_URL))
+HOOK_URL = "https://" + decrypted_hook_url['Plaintext'].decode('utf-8')
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+
+
+def build_slack_message(message):
+    alarm_name = message['AlarmName']
+    old_state = message['OldStateValue']
+    new_state = message['NewStateValue']
+    reason = message['NewStateReason']
+
+    slack_message = f"CloudWatch Alarm state changed for `{alarm_name}`"
+    slack_message += f" from `{old_state}` to `{new_state}`"
+    slack_message += f" because of the following reason:\n```{reason}```"
+
+    return slack_message
 
 
 def notify_slack(event, context):
@@ -23,21 +38,13 @@ def notify_slack(event, context):
     message = json.loads(event['Records'][0]['Sns']['Message'])
     logger.info(f"Message: {str(message)}")
 
-    alarm_name = message['AlarmName']
-    #old_state = message['OldStateValue']
-    new_state = message['NewStateValue']
-    reason = message['NewStateReason']
+    slack_data = {'channel': SLACK_CHANNEL, 'text': build_slack_message(message)}
 
-    slack_message = {
-        'channel': SLACK_CHANNEL,
-        'text': f"{alarm_name} state is now {new_state}: {reason}"
-    }
-
-    req = Request(HOOK_URL, json.dumps(slack_message).encode('utf-8'))
+    req = Request(HOOK_URL, json.dumps(slack_data).encode('utf-8'))
     try:
         response = urlopen(req)
         response.read()
-        logger.info(f"Message posted to {slack_message['channel']}")
+        logger.info(f"Message posted to {slack_data['channel']}")
     except HTTPError as e:
         logger.error(f"Request failed: {e.code} {e.reason}")
     except URLError as e:

--- a/src/event_handler.py
+++ b/src/event_handler.py
@@ -26,11 +26,9 @@ def build_slack_message(message):
     new_state = message['NewStateValue']
     reason = message['NewStateReason']
 
-    slack_message = f"CloudWatch Alarm state changed for `{alarm_name}`"
-    slack_message += f" from `{old_state}` to `{new_state}`"
-    slack_message += f" because of the following reason:\n```{reason}```"
-
-    return slack_message
+    return f"CloudWatch Alarm state changed for `{alarm_name}`" \
+        f" from `{old_state}` to `{new_state}`" \
+        f" because of the following reason:\n```{reason}```"
 
 
 def notify_slack(event, context):


### PR DESCRIPTION
### Old format

<img width="1349" alt="Slack_-_GDS" src="https://user-images.githubusercontent.com/3193694/59212267-dcb39000-8ba9-11e9-959c-cf970b9ff3bd.png">

---

### New format

<img width="1361" alt="Slack_-_Robin_Mitra" src="https://user-images.githubusercontent.com/3193694/59212339-07054d80-8baa-11e9-8703-5d957d20bfc8.png">
